### PR TITLE
Notify when the user explicitly hides the UndoBar.

### DIFF
--- a/library/src/main/java/com/jensdriller/libs/undobar/UndoBar.java
+++ b/library/src/main/java/com/jensdriller/libs/undobar/UndoBar.java
@@ -160,6 +160,7 @@ public final class UndoBar {
      * @param shouldAnimate whether the {@link UndoBar} should animate out
      */
     public void hide(boolean shouldAnimate) {
+        safelyNotifyOnHide();
         mHandler.removeCallbacks(mHideRunnable);
 
         if (shouldAnimate) {


### PR DESCRIPTION
This is very useful for any app using this library on a Listview, example:

Imagine a list of elements.
Each element can be deleted.
When an element is deleted, a new instance of UndoBar is created with a listener, so in the onHide we will really delete the element (make a request to a WS, DB, etc.)*
When another element is deleted, we SHOULD hide the previous UndoBar, create a new one with new params and a new listener.

So the problem here is that if somebody manually hides the UndoBar, the onHide method won't be called, so no action can be performed.

*This is done this way to avoid multiple calls to a WS if the user changes its mind and clicks undo.
