### PR TITLE
Pass the UndoToken to onHide as well

### DIFF
--- a/library/src/main/java/com/jensdriller/libs/undobar/UndoBar.java
+++ b/library/src/main/java/com/jensdriller/libs/undobar/UndoBar.java
@@ -404,8 +404,10 @@ public class UndoBar {
      * Hides the undo bar and notifies potential listener.
      */
     protected void onUndo() {
+        // hide(true) will set mUndoToken to null, so we grab a reference and pass it to safelyNotifyOnHide()
+        Parcelable token = mUndoToken;
         hide(true);
-        safelyNotifyOnUndo();
+        safelyNotifyOnUndo(token);
     }
 
     /**
@@ -420,9 +422,9 @@ public class UndoBar {
     /**
      * Notifies listener if available.
      */
-    protected void safelyNotifyOnUndo() {
+    protected void safelyNotifyOnUndo(Parcelable token) {
         if (mUndoListener != null) {
-            mUndoListener.onUndo(mUndoToken);
+            mUndoListener.onUndo(token);
         }
     }
 

--- a/library/src/main/java/com/jensdriller/libs/undobar/UndoBar.java
+++ b/library/src/main/java/com/jensdriller/libs/undobar/UndoBar.java
@@ -67,7 +67,7 @@ public class UndoBar {
         /**
          * Will be fired when the undo bar disappears without being actioned.
          */
-        void onHide();
+        void onHide(Parcelable token);
 
         /**
          * Will be fired when the undo button is pressed.
@@ -392,8 +392,10 @@ public class UndoBar {
      * Hides the undo bar and notifies potential listener.
      */
     protected void onHide() {
+        // hide(true) will set mUndoToken to null, so we grab a reference and pass it to safelyNotifyOnHide()
+        Parcelable token = mUndoToken;
         hide(true);
-        safelyNotifyOnHide();
+        safelyNotifyOnHide(token);
         mUndoListener = null;
     }
 
@@ -409,9 +411,9 @@ public class UndoBar {
     /**
      * Notifies listener if available.
      */
-    protected void safelyNotifyOnHide() {
+    protected void safelyNotifyOnHide(Parcelable token) {
         if (mUndoListener != null) {
-            mUndoListener.onHide();
+            mUndoListener.onHide(token);
         }
     }
 


### PR DESCRIPTION
pass the token to the listener onHide as well (not just in onUndo). this is useful for doing stuff that is not actually undoable and should only be executed after the user had his chance to undo.
Also included a little fix to avoid a (very very unlikely) race condition.
